### PR TITLE
Improve page layout with shared navbar

### DIFF
--- a/frontend/src/app/ClientLayout.tsx
+++ b/frontend/src/app/ClientLayout.tsx
@@ -3,6 +3,7 @@
 import { ReactNode } from "react";
 import { usePathname } from "next/navigation";
 import DashboardLayout from "./dashboard/layout";
+import Navbar from "./components/Navbar";
 
 interface ClientLayoutProps {
   children: ReactNode;
@@ -20,8 +21,9 @@ export default function ClientLayout({ children }: ClientLayoutProps) {
 
   // For /dashboard, render children directly (no sidebar)
   return (
-    <main className="flex flex-col min-h-screen items-center justify-center bg-gradient-to-br from-gray-50 to-blue-100">
-      {children}
-    </main>
+    <div className="min-h-screen flex flex-col bg-gradient-to-br from-gray-50 to-blue-100">
+      <Navbar />
+      <main className="flex-1 flex flex-col items-center justify-center p-4">{children}</main>
+    </div>
   );
-} 
+}

--- a/frontend/src/app/components/Navbar.tsx
+++ b/frontend/src/app/components/Navbar.tsx
@@ -1,0 +1,12 @@
+"use client";
+import Link from "next/link";
+
+export default function Navbar() {
+  return (
+    <header className="w-full bg-white/70 backdrop-blur border-b border-gray-100 py-4 px-6 shadow-sm">
+      <Link href="/" className="text-2xl font-bold text-blue-700 hover:text-blue-800">
+        Email AI Writer
+      </Link>
+    </header>
+  );
+}


### PR DESCRIPTION
## Summary
- add a simple Navbar component for brand header
- include the Navbar in `ClientLayout` so non-dashboard pages share the same layout

## Testing
- `npm test` *(fails: no tests found)*

------
https://chatgpt.com/codex/tasks/task_e_686015fa5de48328ae071736dcedd9cb

## Summary by Sourcery

Add a shared Navbar component and integrate it into ClientLayout to unify the layout across non-dashboard pages.

New Features:
- Introduce a Navbar component for the brand header

Enhancements:
- Embed Navbar into ClientLayout and restructure the page container to include the shared Navbar for non-dashboard pages